### PR TITLE
Add tests for attempts to navigate to a specific URL - negative tests

### DIFF
--- a/html/browsers/history/the-history-interface/history_go_to_uri-1.html
+++ b/html/browsers/history/the-history-interface/history_go_to_uri-1.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<script src="history.js"></script>
+<script>
+  onunload = function() {}
+
+  onload = function() {
+    if (!opener.started) {
+      queue_next();
+    } else {
+      opener.pages.push(id);
+      opener.start_test_wait();
+      if (!opener.gone) {
+          history.go("history_entry.html");
+          opener.gone = true;
+      }
+    }
+  };
+</script>

--- a/html/browsers/history/the-history-interface/history_go_to_uri.html
+++ b/html/browsers/history/the-history-interface/history_go_to_uri.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<title>history.go()</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<div id="log"></div>
+<script>
+  var t = async_test(undefined, {timeout:5000});
+  started = false;
+  gone = false;
+  pages = []
+  timer = null;
+  start_test_wait = t.step_func(
+    function() {
+      clearTimeout(timer);
+      timer = setTimeout(t.step_func(
+        function() {
+          try {
+            assert_array_equals(pages, [3, 2, 2], "Pages opened during history navigation");
+            t.done();
+          } finally {
+            win.close();
+          }
+        }
+      ), 500);
+    }
+  );
+  t.step(function() {win = window.open("history_entry.html?urls=history_go_to_uri-1.html,history_forward-2.html");
+});
+</script>


### PR DESCRIPTION
Upon attempting to navigate to a URL in the history, Edge used to navigate to it. This should be fixed in current Edge insider flights. Add a test for it.